### PR TITLE
Fixing broken dependency due to recent mime 2.0 release 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./staticGzip.js",
   "dependencies": {
     "send": ">=0.1",
-    "mime": ">=0.0.1",
+    "mime": "1.4.0",
     "mkdirp": ">=0.5.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./staticGzip.js",
   "dependencies": {
     "send": ">=0.1",
-    "mime": "1.4.0",
+    "mime": "^1.4.0",
     "mkdirp": ">=0.5.1"
   },
   "engines": {


### PR DESCRIPTION
Hello,

A couple of days ago, [mine](https://www.npmjs.com/package/mime) npm package was been updated to version 2, which is a breaking change from 1.x.  It requires node.js version >= 6.0

static-gzip package no longer works with node.js version < 6.0

In order to still support older versions of node, I've updated the mime dependency in the package.json file to the lastest 1.x version.  

This fixed my issue on node.js version 0.12.9

I appreciate you taking the time to review pull request.

-Ramon Lopez